### PR TITLE
A malloc/free implementation that works with the incremental GC in AS 0.18.14 (binaryen 100.0.0).

### DIFF
--- a/assembly/malloc.ts
+++ b/assembly/malloc.ts
@@ -1,16 +1,17 @@
+// NOTE: `--runtime incremental` must be specified, which is assemblyscript 0.18.14's default.
 import {
-  __retain,
-  __release,
-} from "rt/index-full";
+  __pin,
+  __unpin,
+} from "rt/itcms";
 
 /// Allow host to allocate memory.
 export function malloc(size: i32): usize {
   let buffer = new ArrayBuffer(size);
   let ptr = changetype<usize>(buffer);
-  return __retain(ptr);
+  return __pin(ptr);
 }
 
 /// Allow host to free memory.
 export function free(ptr: usize): void {
-  __release(ptr);
+  __unpin(ptr);
 }


### PR DESCRIPTION
With a pair of noop HTTP and TCP filters in Istio 1.9.1, this is an improvement
over AS 0.14.9's runtime because it does not leak memory (or leaks it
incredibly slowly).

The noop filter is:
```
export * from "@solo-io/proxy-runtime/proxy";
import { RootContext, Context, registerRootContext, FilterHeadersStatusValues, stream_context } from "@solo-io/proxy-runtime";

class NoopRoot extends RootContext {
  createContext(context_id: u32): Context {
      return new Noop(context_id, this);
  }
}

class Noop extends Context {
  onResponseHeaders(a: u32, end_of_stream: bool): FilterHeadersStatusValues { return FilterHeadersStatusValues.Continue }
}

registerRootContext((context_id: u32) => {
    return new NoopRoot(context_id);
}, "noop-filter");
```